### PR TITLE
feat: Adding acm creation and validation

### DIFF
--- a/examples/gitops/argocd-multi-cluster/README.md
+++ b/examples/gitops/argocd-multi-cluster/README.md
@@ -57,24 +57,23 @@ service : {
 
 ### (Option 2) Ingress
 You will be able to use ArgoCD with a valid SSL certificate on a domain (i.e. argocd.example.com)
+You can use a registered domain you control or register a new one following the instructions [here](https://aws.amazon.com/getting-started/hands-on/get-a-domain/).
+
+To enable this option, use:
+```
+export TF_VAR_enable_ingress=true
+```
 
 #### Create DNS Hosted Zone in Route 53
-You can use the Console, or the `aws` cli
-```sh
-aws route53 create-hosted-zone --name 'example.com' --caller-reference "$(date)"
+In this step you will delegate your registered domain DNS to Amazon Route53. You can either delegate the top level domain or a subdomain.
 ```
-
-#### Create domain certificate in ACM, for example
-You can use the Console, or the `aws` cli
-```sh
-aws acm request-certificate --domain-name '*.example.com' --validation-method DNS
+export TF_VAR_domain_name=<my-registered-domain> # For example: example.com or subdomain.example.com
 ```
-
-#### Setup Domain
-Set the sub domain for argocd
+You can use the Console, or the `aws` cli to create a hosted zone. Execute the following command only once:
 ```sh
-export TF_VAR_argocd_domain=example.com
+aws route53 create-hosted-zone --name $TF_VAR_domain_name --caller-reference "$(date)"
 ```
+Use the NameServers in the DelegatoinSet to update your registered domain NS records at the registrar. 
 
 ## Deploy Hub Cluster
 After selecting LoadBalancer or Ingress for ArgoCD, deploy the Hub Cluster

--- a/examples/gitops/argocd-multi-cluster/hub-cluster/main.tf
+++ b/examples/gitops/argocd-multi-cluster/hub-cluster/main.tf
@@ -40,10 +40,10 @@ provider "kubectl" {
 provider "bcrypt" {}
 
 # To get the hosted zone to be use in argocd domain
-data "aws_route53_zone" "argocd" {
-  count        = local.argocd_domain == "" ? 0 : 1
-  name         = local.argocd_domain
-  private_zone = local.argocd_domain_private_zone
+data "aws_route53_zone" "domain_name" {
+  count        = var.enable_ingress ? 1 : 0
+  name         = local.domain_name
+  private_zone = var.domain_private_zone
 }
 
 data "aws_caller_identity" "current" {}
@@ -61,6 +61,7 @@ data "aws_iam_policy_document" "irsa_policy" {
 locals {
   name             = "hub-cluster"
   hub_cluster_name = var.hub_cluster_name
+  domain_name      = var.domain_name
 
   cluster_version = "1.24"
 
@@ -77,9 +78,7 @@ locals {
 
   argocd_namespace           = "argocd"
   argocd_subdomain           = "argocd"
-  argocd_domain              = var.argocd_domain
-  argocd_domain_arn          = data.aws_route53_zone.argocd[0].arn
-  argocd_domain_private_zone = var.argocd_domain_private_zone
+  argocd_domain_arn          = data.aws_route53_zone.domain_name[0].arn
 
   # Multi-{account,region} setup
   region      = var.hub_region
@@ -90,9 +89,9 @@ locals {
     issuer       = var.argocd_sso_issuer
     clientID     = var.argocd_sso_client_id
     clientSecret = var.argocd_sso_client_secret
-    logoutURL    = "${var.argocd_sso_logout_url}?client_id=${var.argocd_sso_client_id}&logout_uri=https://${local.argocd_subdomain}.${local.argocd_domain}/logout"
+    logoutURL    = "${var.argocd_sso_logout_url}?client_id=${var.argocd_sso_client_id}&logout_uri=https://${local.argocd_subdomain}.${local.domain_name}/logout"
     cliClientID  = var.argocd_sso_cli_client_id
-    url          = "https://${local.argocd_subdomain}.${local.argocd_domain}"
+    url          = "https://${local.argocd_subdomain}.${local.domain_name}"
   }) : ""
 }
 
@@ -210,10 +209,10 @@ module "eks_blueprints_kubernetes_addons" {
                 "alb.ingress.kubernetes.io/listen-ports" : "[{\"HTTPS\":443}]"
                 "alb.ingress.kubernetes.io/tags" : "Environment=hub,GitOps=true"
               }
-              hosts : ["${local.argocd_subdomain}.${local.argocd_domain}"]
+              hosts : ["${local.argocd_subdomain}.${local.domain_name}"]
               tls : [
                 {
-                  hosts : ["${local.argocd_subdomain}.${local.argocd_domain}"]
+                  hosts : ["${local.argocd_subdomain}.${local.domain_name}"]
                 }
               ]
               ingressClassName : "alb"
@@ -252,7 +251,7 @@ module "eks_blueprints_kubernetes_addons" {
   enable_aws_load_balancer_controller = true                      # ArgoCD UI depends on aws-loadbalancer-controller for Ingress
   enable_metrics_server               = true                      # ArgoCD HPAs depend on metric-server
   enable_external_dns                 = true                      # ArgoCD Server and UI use valid https domain name
-  external_dns_route53_zone_arns      = [local.argocd_domain_arn] # ArgoCD Server and UI domain name is registered in Route 53
+  external_dns_route53_zone_arns      = [data.aws_route53_zone.domain_name[0].arn] # ArgoCD Server and UI domain name is registered in Route 53
 
   enable_crossplane = false
   crossplane_helm_config = {
@@ -444,4 +443,31 @@ module "vpc" {
   }
 
   tags = local.tags
+}
+
+
+################################################################################
+# ACM Certificate
+################################################################################
+
+resource "aws_acm_certificate" "cert" {
+  count               = var.enable_ingress ? 1 : 0
+  domain_name         = "*.${local.domain_name}"
+  validation_method   = "DNS"
+}
+
+resource "aws_route53_record" "cert" {
+  count           = var.enable_ingress ? 1 : 0
+  zone_id         = data.aws_route53_zone.domain_name[0].zone_id
+  name            = tolist(aws_acm_certificate.cert[0].domain_validation_options)[0].resource_record_name
+  type            = tolist(aws_acm_certificate.cert[0].domain_validation_options)[0].resource_record_type
+  records         = [tolist(aws_acm_certificate.cert[0].domain_validation_options)[0].resource_record_value]
+  ttl             = 60
+  allow_overwrite = true
+}
+
+resource "aws_acm_certificate_validation" "cert" {
+  count                   = var.enable_ingress ? 1 : 0
+  certificate_arn         = aws_acm_certificate.cert[0].arn
+  validation_record_fqdns = [for record in aws_route53_record.cert : record.fqdn]
 }

--- a/examples/gitops/argocd-multi-cluster/hub-cluster/outputs.tf
+++ b/examples/gitops/argocd-multi-cluster/hub-cluster/outputs.tf
@@ -4,5 +4,5 @@ output "configure_kubectl" {
 }
 output "argocd_login" {
   description = "ArgoCD CLI login command"
-  value       = "argocd login argocd.${local.argocd_domain} --username admin"
+  value       = "argocd login argocd.${local.domain_name} --username admin"
 }

--- a/examples/gitops/argocd-multi-cluster/hub-cluster/outputs.tf
+++ b/examples/gitops/argocd-multi-cluster/hub-cluster/outputs.tf
@@ -4,5 +4,5 @@ output "configure_kubectl" {
 }
 output "argocd_login" {
   description = "ArgoCD CLI login command"
-  value       = "argocd login argocd.${local.domain_name} --username admin"
+  value       = "argocd login ${local.argocd_subdomain}.${local.domain_name} --username admin"
 }

--- a/examples/gitops/argocd-multi-cluster/hub-cluster/variables.tf
+++ b/examples/gitops/argocd-multi-cluster/hub-cluster/variables.tf
@@ -1,56 +1,71 @@
-variable "hub_cluster_name" {
-  description = "Hub Cluster Name"
-  type        = string
-  default     = "hub-cluster"
-}
-variable "hub_region" {
-  description = "Hub Cluster Region"
-  type        = string
-  default     = "us-west-2"
-}
-variable "hub_profile" {
-  description = "Hub Cluster CLI Profile"
-  type        = string
-  default     = "default"
-}
-variable "argocd_domain" {
-  description = "Hosted Zone domain"
-  type        = string
-  default     = "exmaple.com"
-}
-variable "argocd_domain_private_zone" {
-  description = "Is ArgoCD private zone"
-  type        = bool
-  default     = false
-}
-variable "argocd_enable_sso" {
-  description = "Enable SSO for ArgoCD"
-  type        = bool
-  default     = false
-}
-variable "argocd_sso_issuer" {
-  description = "ArgoCD SSO OIDC issuer"
+variable "argocd_sso_cli_client_id" {
+  description = "ArgoCD SSO OIDC cliClientID"
   type        = string
   default     = ""
 }
+
 variable "argocd_sso_client_id" {
   description = "ArgoCD SSO OIDC clientID"
   type        = string
   default     = ""
 }
+
+variable "domain_private_zone" {
+  description = "Is ArgoCD private zone"
+  type        = bool
+  default     = false
+}
+
+variable "argocd_enable_sso" {
+  description = "Enable SSO for ArgoCD"
+  type        = bool
+  default     = false
+}
+
 variable "argocd_sso_client_secret" {
   description = "ArgoCD SSO OIDC clientSecret"
   type        = string
   default     = ""
   sensitive   = true
 }
+
+variable "argocd_sso_issuer" {
+  description = "ArgoCD SSO OIDC issuer"
+  type        = string
+  default     = ""
+}
+
 variable "argocd_sso_logout_url" {
   description = "ArgoCD SSO OIDC logoutURL"
   type        = string
   default     = ""
 }
-variable "argocd_sso_cli_client_id" {
-  description = "ArgoCD SSO OIDC cliClientID"
+
+variable "domain_name" {
+  description = "Domain Name"
   type        = string
-  default     = ""
+}
+
+variable "enable_ingress" {
+  description = "Enable ingress"
+  type        = bool
+  default     = false
+}
+
+variable "hub_cluster_name" {
+  description = "Hub Cluster Name"
+  type        = string
+  default     = "hub-cluster"
+}
+
+variable "hub_profile" {
+  description = "Hub Cluster CLI Profile"
+  type        = string
+  default     = "default"
+}
+
+variable "hub_region" {
+  description = "Hub Cluster Region"
+  type        = string
+  default     = "us-west-2"
 }


### PR DESCRIPTION
### What does this PR do?
- Added acm creation and validation
- Added switch for `enable_ingress`, currently used for acm only, to be used for the helm chart
- Sorted variables in alphabetical order and added white-spaces
- Updated Readme

### Testing
Tested acm creation and validation in my AWS account.